### PR TITLE
Update formula to v1.0.42

### DIFF
--- a/Formula/bkl.rb
+++ b/Formula/bkl.rb
@@ -1,6 +1,6 @@
 class Bkl < Formula
-  @@tag = "v1.0.41"
-  sha256 "6f932f17882fea96f5a5fdd5e47b1e15cdbfa06f9be8a1d203ce76a334f17d97"
+  @@tag = "v1.0.42"
+  sha256 "2ca35a1bdb3c11a37217f40b6d6432c10b7e8e53e52579a13040322dcbaec092"
 
   desc "Evaluates bkl configuration layer files"
   homepage "https://bkl.gopatchy.io"


### PR DESCRIPTION
**Motivation**

A newer release (one patch version higher) is available than what the formula is specifying. See: https://github.com/gopatchy/homebrew-bkl/blob/main/Formula/bkl.rb#L2 `@@tag = "v1.0.41"`  vs. https://github.com/gopatchy/bkl/releases/tag/v1.0.42

**Changes**

* Update the tag to `1.0.42`
* Update sha256, computed with: `curl -vOL https://github.com/gopatchy/bkl/archive/refs/tags/v1.0.42.tar.gz && sha256sum v1.0.42.tar.gz`